### PR TITLE
Fixed component config to properly read from ludo.json

### DIFF
--- a/lib/LudoProject.js
+++ b/lib/LudoProject.js
@@ -48,7 +48,7 @@ function LudoProject(ludoDirectory, projectDirectory, command, options, componen
     //now that we have all of the information, we can figure out things like
     //the target, paper, and all the different files that are going to be used
     this.config = config;
-    this.componentConfig = config && config[this.component] || {};
+    this.componentConfig = config && config.components && config.components[this.component] || {};
     this.finalConfigs = _.extendOwn({},DEFAULTS,this.config,this.componentConfig,options);
     
     //as part of the initial setup lets make sure that the less code is compiled


### PR DESCRIPTION
When running `ludo new [component_name]` it generates a components object, and puts the components name there. This change makes that actually be picked up properly.
