### PR TITLE
Added the ability to specify options for specific commands

### DIFF
--- a/lib/LudoProject.js
+++ b/lib/LudoProject.js
@@ -49,7 +49,8 @@ function LudoProject(ludoDirectory, projectDirectory, command, options, componen
     //the target, paper, and all the different files that are going to be used
     this.config = config;
     this.componentConfig = config && config.components && config.components[this.component] || {};
-    this.finalConfigs = _.extendOwn({},DEFAULTS,this.config,this.componentConfig,options);
+    this.commandConfig = config && config.commands && config.commands[this.command] || {};
+    this.finalConfigs = _.extendOwn({},DEFAULTS,this.config,this.componentConfig,this.commandConfig,options);
     
     //as part of the initial setup lets make sure that the less code is compiled
     if(this.usingLess() && command !== "new"){


### PR DESCRIPTION
I added the ability to specify a command specific map. This was added because I was sick of stopping my `design` each time I wanted to `draw`.

Example usage:

``` json
{
    "target": "pnp",
    "paper": "letter",
    "templ": "jade",
    "less": true,
    "csvParams": {
        "ignoreEmpty": true  
    },
    "components": {
        "powers": {
            "output": "powers.pdf",
            "port": 3002
        },
        "rulers": {
            "output": "rulers.pdf",
            "port": 3003
        }
    },
    "commands": {
        "draw":{
            "port": 3001
        }
    }
}
```

This lets me design all cards, while still drawing on command.
